### PR TITLE
Fix check bounce rules not matching headers

### DIFF
--- a/public_html/lists/admin/checkbouncerules.php
+++ b/public_html/lists/admin/checkbouncerules.php
@@ -30,7 +30,7 @@ $unmatched = 0;
 $matched = 0;
 $req = Sql_Query(sprintf('select * from %s where comment != "not processed" %s', $GLOBALS['tables']['bounce'], $limit));
 while ($row = Sql_Fetch_Array($req)) {
-    $action = matchBounceRules($row['data'], $bouncerules);
+    $action = matchBounceRules($row['header'] . "\n\n" . $row['data'], $bouncerules);
     if ($action) {
         #  print $row['comment']. " Match: $action<br/>";
         ++$matched;


### PR DESCRIPTION
Headers are parsed by bounce rules, but not when you check bounces, see https://mantis.phplist.org/view.php?id=16909 for original change.
